### PR TITLE
Fix Georgian flag

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -876,7 +876,7 @@
 
 - name: Georgian
   iso: kat
-  flag: BG.svg
+  flag: GE.svg
   forms: 74412
   paradigms: 3782
   nouns: yes


### PR DESCRIPTION
The Georgian section for downloading data was wrongly using the Bulgarian flag.