### PR TITLE
Update languages.yml by Gujarati language info

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -410,6 +410,19 @@
   templatic: no
   type: living
 
+- name: Gujarati
+  iso: guj
+  flag: IN.svg
+  forms: 19,404
+  paradigms: 6,995
+  nouns: yes
+  verbs: yes
+  adjectives: yes
+  typology: agglutinative
+  templatic: no
+  type: living
+
+
 - name: Modern Greek
   iso: ell
   flag: GR.svg


### PR DESCRIPTION
Adding Gujarati language info:

- name: Gujarati
  iso: guj
  flag: IN.svg
  forms: 19,404
  paradigms: 6,995
  nouns: yes
  verbs: yes
  adjectives: yes
  typology: agglutinative
  templatic: no
  type: living